### PR TITLE
Updating different papers to bibsonomy

### DIFF
--- a/bibsonomy-uploader-cli/pom.xml
+++ b/bibsonomy-uploader-cli/pom.xml
@@ -53,6 +53,12 @@
 	  <artifactId>javax.activation</artifactId>
 	  <version>1.2.0</version>
 	</dependency>
+	<!-- https://mvnrepository.com/artifact/org.javers/javers-core -->
+	<dependency>
+	    <groupId>org.javers</groupId>
+	    <artifactId>javers-core</artifactId>
+	    <version>5.9.2</version>
+	</dependency>
     </dependencies>
 </project>
 

--- a/bibsonomy-uploader-cli/src/main/java/org/aksw/bibuploader/BibUpdater.java
+++ b/bibsonomy-uploader-cli/src/main/java/org/aksw/bibuploader/BibUpdater.java
@@ -205,14 +205,10 @@ public class BibUpdater {
 		
 		// present in B and in F, updates based on file entry if different
 		List<Post<BibTex>> intersection = getPaperIntersection(fileEntries, accountEntries);
-		//int alCount = 0;
 		for(Post<BibTex> post:intersection) {
 			Post<BibTex> matchingPost = accountEntries.stream().filter(a -> a.getResource().getIntraHash().equals(post.getResource().getIntraHash()))
 					.findFirst().orElse(null);
-			if(post.getResource().getTitle().equals("FAIR.ReD: Semantic knowledge graph infrastructure for the life sciences"))
-				System.out.println();
 			if(matchingPost != null && isSame(matchingPost, post)) {
-				//alCount++;
 				log.info(post.getResource().getTitle() + " already there");
 			} else {
 				updateEntry(post);
@@ -275,6 +271,9 @@ public class BibUpdater {
 	
 	public boolean isSame(Post<BibTex> accountEntry, Post<BibTex> filePost) {
 		
+		if(filePost.getTags()==null||filePost.getTags().isEmpty())
+			filePost.addTag("nokeyword");
+		
 		Javers javers = JaversBuilder.javers().build();
 		Diff diff = javers.compare(accountEntry, filePost);
 		
@@ -284,8 +283,6 @@ public class BibUpdater {
 		for (Change curChange : changes) {
 			String typeName = curChange.getAffectedGlobalId().getTypeName();
 			if (curChange instanceof ObjectRemoved) {
-				if(typeName.equals("org.bibsonomy.model.Tag") && accountEntry.getTags().contains(new Tag("nokeyword"))) 
-					continue;
 				if(!(typeName.equals("org.bibsonomy.model.Group") || typeName.equals("org.bibsonomy.model.User"))) 
 					return false;
 			} else if (curChange instanceof ValueChange) {
@@ -298,8 +295,6 @@ public class BibUpdater {
 					return false;
 			} else if (curChange instanceof SetChange) {
 				String propertyName = ((SetChange) curChange).getPropertyName();
-				if(typeName.equals("org.bibsonomy.model.Post") && propertyName.equals("tags") && accountEntry.getTags().contains(new Tag("nokeyword")))
-					continue;
 				if(!(typeName.equals("org.bibsonomy.model.Post") && propertyName.equals("groups"))) 
 					return false;
 			} else {

--- a/bibsonomy-uploader-cli/src/main/java/org/aksw/bibuploader/Summary.java
+++ b/bibsonomy-uploader-cli/src/main/java/org/aksw/bibuploader/Summary.java
@@ -1,0 +1,65 @@
+package org.aksw.bibuploader;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class Summary {
+	private Set<String> duplicates;
+	private int sucAdded;
+	private Set<String> failedAdditions;
+	private int noUpdated;
+	private int noRemoved;
+	private Set<String> noTagEntries;
+
+	public Summary() {
+		duplicates = new HashSet<String>();
+		failedAdditions = new HashSet<String>();
+		noTagEntries = new HashSet<String>();
+	}
+
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("\nDuplicates found in the given file:\n");
+		for (String duplicate : duplicates)
+			builder.append(duplicate.toString()).append("\n");
+
+		builder.append("\nPosts without keywords in the given file:\n");
+		for (String missingTag : noTagEntries)
+			builder.append(missingTag.toString()).append("\n");
+
+		builder.append("\nSummary:\n");
+		builder.append(duplicates.size()).append("\tDuplicates found in the given file (see titles above)\n");
+		builder.append(noTagEntries.size()).append("\tPosts without keywords in the given file (see titles above)\n");
+		builder.append(sucAdded).append("\tPapers were added to bibsonomy\n");
+		builder.append(failedAdditions.size()).append("\tPapers couldn't be added\n");
+		
+		builder.append(noRemoved).append("\tPapers were deleted from bibsonomy\n");
+		builder.append(noUpdated).append("\tPapers were updated\n\n");
+
+		return builder.toString();
+	}
+
+	public void addDuplicate(String dup) {
+		duplicates.add(dup);
+	}
+
+	public void addNoTagEntry(String missingTagEntry) {
+		noTagEntries.add(missingTagEntry);
+	}
+
+	public void addSucAdd() {
+		sucAdded++;
+	}
+
+	public void addFailAdd(String failed) {
+		failedAdditions.add(failed);
+	}
+
+	public void addUpdate() {
+		noUpdated++;
+	}
+
+	public void setRemoved(int removed) {
+		noRemoved = removed;
+	}
+}


### PR DESCRIPTION
The following has been implemented:
1. Adding the paper to bibsonomy, if present in the file and not yet uploaded
2. Removing the paper from bibsonomy, if absent in the file
3. Updating the papers that are present in the file and in bibsonomy, but have differences (used javers library to check the differences).
Since bibsonomy seems to modify some attributes while uploading, I considered 2 papers the same if they have the same intrahash, and only these attributes differ between them.

The previous implementation was not fetching all posts from bibsonomy, since the API only allows 1000 entries to be fetched at a time. I added a method as to retrieve all entries.
